### PR TITLE
chore: upgrade go base image to 1.23.0

### DIFF
--- a/prairie-server/Dockerfile
+++ b/prairie-server/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.22-alpine AS build
+FROM golang:1.23.0-alpine AS build
 WORKDIR /src
 COPY go.mod ./
 RUN go mod download


### PR DESCRIPTION
## Summary
- update the Go build stage in the API Dockerfile to use Go 1.23.0 on Alpine

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d31ecff9a08323b55fc8b712a500d6