### PR TITLE
Configure database path via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Simple AI generated turn-based game
    docker compose up --build
    ```
 2. Open the application in your browser: [http://localhost:8080](http://localhost:8080)
+
+The API service stores state in a SQLite database whose location can be configured with the `PRAIRIE_DB_PATH` environment variable. By default it uses `/tmp/prairie.db`, which is writable by the non-root container user. To persist data between runs, override `PRAIRIE_DB_PATH` and mount a volume at that path.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,12 @@ services:
   api:
     build: ./prairie-server
     container_name: prairie-api
+    environment:
+      - PRAIRIE_DB_PATH=/data/prairie.db
     expose:
       - "8080"         # internal only
+    volumes:
+      - prairie-data:/data
   web:
     build: ./frontend
     container_name: prairie-web
@@ -11,3 +15,6 @@ services:
       - "8080:80"      # http://localhost:8080
     depends_on:
       - api
+
+volumes:
+  prairie-data:

--- a/prairie-server/main.go
+++ b/prairie-server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 	"time"
 
 	"example.com/prairie/api"
@@ -10,7 +11,12 @@ import (
 
 func main() {
 	// Core singletons
-	st, err := game.NewStorage("prairie.db")
+	dbPath := os.Getenv("PRAIRIE_DB_PATH")
+	if dbPath == "" {
+		dbPath = "/tmp/prairie.db"
+	}
+
+	st, err := game.NewStorage(dbPath)
 	if err != nil {
 		log.Fatalf("failed to initialize storage: %v", err)
 	}


### PR DESCRIPTION
## Summary
- allow the server to read the SQLite database path from the PRAIRIE_DB_PATH environment variable, defaulting to /tmp/prairie.db for a writable location
- document the new default path and configuration in the README
- configure docker-compose to persist the database by setting PRAIRIE_DB_PATH and mounting a volume

## Testing
- docker compose up --build --detach *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c5b3b2448323a2d693cb9582d03f