### PR TITLE
Ensure SQLite storage directory exists before opening DB

### DIFF
--- a/prairie-server/Dockerfile
+++ b/prairie-server/Dockerfile
@@ -5,9 +5,11 @@ COPY go.mod ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o /out/server .
+RUN mkdir -p /out/data
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /out/server /server
+COPY --from=build --chown=nonroot:nonroot /out/data /data
 EXPOSE 8080
 USER nonroot:nonroot
 ENTRYPOINT ["/server"]

--- a/prairie-server/game/storage.go
+++ b/prairie-server/game/storage.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 
@@ -47,6 +49,11 @@ func NewStorage(dbPath string) (*Storage, error) {
 	st.resetInMemory()
 
 	if dbPath != "" {
+		if dir := filepath.Dir(dbPath); dir != "." && dir != "" {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return nil, err
+			}
+		}
 		db, err := sql.Open("sqlite", dbPath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary
- ensure the directory for PRAIRIE_DB_PATH exists before initializing SQLite storage
- add filesystem creation step so the API container can start with a mounted volume

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d3c7a202e48323856a05abced3c902